### PR TITLE
Update style.css so the `=` symbol is aligned correctly.

### DIFF
--- a/content/style.css
+++ b/content/style.css
@@ -25,7 +25,7 @@ tr.base_example td{
 	border-top: 1px solid black;
 	border-bottom: 1px solid black;
 	padding: 2px;
-	vertical-align:bottom;
+	vertical-align: baseline;
 }
 tr.base_example td.separator{
 	background: #fff0f0;


### PR DESCRIPTION
I have changed the vertical-align of td to baseline so the equals symbol is aligned to the main line and not to the sub.
