### PR TITLE
Update C# documentation links

### DIFF
--- a/content/languages/csharp.html
+++ b/content/languages/csharp.html
@@ -29,10 +29,10 @@ The <code>Math.Round()</code> method works with the double and decimal types, an
 
 Resources 
 ---------
-* [C# Reference](http://msdn.microsoft.com/en-us/library/618ayhy6%28v=VS.80%29.aspx)
-   * [float type](http://msdn.microsoft.com/en-us/library/b1e65aza%28v=VS.80%29.aspx)  
-   * [double type](http://msdn.microsoft.com/en-us/library/678hzkk9%28v=VS.80%29.aspx)  
-   * [decimal type](http://msdn.microsoft.com/en-us/library/364x0z75%28v=VS.80%29.aspx)  
-   * [Math.Round()](http://msdn.microsoft.com/en-US/library/system.math.round%28v=VS.80%29.aspx)
+* [C# Reference](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/index)
+   * [float type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/float)  
+   * [double type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/double)  
+   * [decimal type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/decimal)  
+   * [Math.Round()](https://docs.microsoft.com/en-us/dotnet/api/system.math.round)
 
 


### PR DESCRIPTION
Existing links are dead.  Yeah, seriously!  That's the point of the redirect links!
Update links to use the new docs.microsoft.com based endpoints.