### PR TITLE
Fix small errors about subnormals

### DIFF
--- a/content/formats/fp.html
+++ b/content/formats/fp.html
@@ -48,13 +48,13 @@ Nearly all hardware and programming languages use floating-point numbers in the 
 | Format | Total bits | Significand bits | Exponent bits | Smallest number | Largest number |
 |--------|------------|------------------|---------------|-----------------|----------------|
 | Single precision | 32 | 23 + 1 sign | 8  | ca. 1.2 &sdot; 10<sup>-38</sup> | ca. 3.4 &sdot; 10<sup>38</sup>|
-| Double precision | 64 | 52 + 1 sign | 11 | ca. 5.0 &sdot; 10<sup>-324</sup> | ca. 1.8 &sdot; 10<sup>308</sup> |
+| Double precision | 64 | 52 + 1 sign | 11 | ca. 2.2 &sdot; 10<sup>-308</sup> | ca. 1.8 &sdot; 10<sup>308</sup> |
 
 Note that there are some peculiarities:
 
 * The **actual bit sequence** is the sign bit first, followed by the exponent and finally the significand bits.
 * The exponent does not have a sign; instead an **exponent bias** is subtracted from it (127 for single and 1023 for double precision). This, and the bit sequence, allows floating-point numbers to be compared and sorted correctly even when interpreting them as integers.
-* The significand's most significant digit is omitted and assumed to be 1, except for **subnormal numbers** which are marked by an all-0 exponent and allow a number range beyond the smallest and largest numbers given in the table above, at the cost of precision.
+* The significand's most significant digit is omitted and assumed to be 1, except for **subnormal numbers** which are marked by an all-0 exponent and allow a number range beyond the smallest numbers given in the table above, at the cost of precision.
 * There are separate **positive and a negative zero** values, differing in the sign bit, where all other bits are 0. These must be considered equal even though their bit patterns are different.
 * There are special **positive and negative infinity** values, where the exponent is all 1-bits and the significand is all 0-bits. These are the results of calculations where the positive range of the exponent is exceeded, or division  of a regular number by zero.
 * There are special **not a number** (or NaN) values where the exponent is all 1-bits and the significand is *not* all 0-bits. These represent the result of various undefined calculations (like multiplying 0 and infinity, any calculation involving a NaN value, or application-specific cases). Even bit-identical NaN values must *not* be considered equal.


### PR DESCRIPTION
The text stated that subnormal numbers “allow a number range beyond the smallest _and largest_ numbers given in the table above”. This pull request removes the italicized words, as subnormals extend the range only to smaller numbers.

Also, the above implies that the ranges in the table are those of normal numbers. This was the case for single precision, but the smallest double precision number quoted in the table was actually the smallest subnormal. This is also fixed in the pull request.