### PR TITLE
Fixes broken link

### DIFF
--- a/content/references.html
+++ b/content/references.html
@@ -6,7 +6,7 @@ description: Documents with more in-depth information about floating-point math
 Documents that contain more in-depth information about the topics
 covered on this wbesite:
 
-* [Homepage of the IEEE 754 standard](http://grouper.ieee.org/groups/754/)
+* [The last version of IEEE 754 standard](https://standards.ieee.org/content/ieee-standards/en/standard/754-2019.html)
 * [What Every Computer Scientist Should Know About Floating-Point Arithmetic](http://download.oracle.com/docs/cd/E19957-01/806-3568/ncg_goldberg.html)
 * [Homepage of William Kahan (architect of the IEEE 754 standard, lots of interesting links)](http://www.cs.berkeley.edu/~wkahan/)
 * [Decimal Arithmetic FAQ ](http://speleotrove.com/decimal/decifaq.html)


### PR DESCRIPTION
It seems like there's no page of 754 working group on ieee.org website any more. 
So link for homepage is replaced with link for draft of 754-2019 which has most important information/links.