### PR TITLE
Update Ruby resources links

### DIFF
--- a/content/languages/ruby.html
+++ b/content/languages/ruby.html
@@ -33,6 +33,6 @@ To print to standard output:
 		
 Resources 
 ---------
-* [Floating Point Arithmetic](http://www.ruby-doc.org/core-2.1.2/Float.html)
-* [The bigdecimal module](http://www.ruby-doc.org/stdlib-2.1.2/libdoc/bigdecimal/rdoc/index.html)
-* [String formatting in Ruby](http://www.ruby-doc.org/core-2.1.2/String.html)
+* [Floating Point Arithmetic](https://ruby-doc.org/core-2.6.3/Float.html)
+* [The bigdecimal module](https://ruby-doc.org/stdlib-2.6.3/libdoc/bigdecimal/rdoc/BigDecimal.html)
+* [String formatting in Ruby](https://ruby-doc.org/core-2.6.3/String.html)


### PR DESCRIPTION
Hello, first of all thank you for your work with the floating point guide, I think it's a great asset.

I'm a Ruby fan, and I was looking into the Ruby section and realised two things:

1. Links to Ruby-doc were not working due to how they are working out http -> https redirection on their end. I know it's not a problem caused by this project, but it is easily solvable redirecting to the https link (which should be better).
2. Links were pointing to Ruby 2.1.2 version. Ruby 2.1 support ended on March 2017, so it doesn't hurt to have something a little bit more updated, since we are already making some changes on this.

It was my pleasure to do this, and I hope to see the floating point guide being a great asset and reference for all developers out there.
