### PR TITLE
Change print statement to print function

### DIFF
--- a/content/languages/python.html
+++ b/content/languages/python.html
@@ -28,7 +28,7 @@ To get a string:
 		
 To print to standard output:
 
-		print "%.2f" % 1.2399 # just use print and string formatting
+		print("%.2f" % 1.2399) # just use print and string formatting
 		
 Specific [rounding modes](/errors/rounding/) and other parameters can be defined in a Context object:
 


### PR DESCRIPTION
Now that Python 2.X is EOL, I thought I'd go ahead and change the python `print` statement to the `print()` function since newcomers are more likely (hopefully) to be using Python3.