### PR TITLE
added Link: toFixed()

### DIFF
--- a/content/languages/javascript.html
+++ b/content/languages/javascript.html
@@ -48,4 +48,4 @@ Resources
 * [Core JavaScript Reference](https://developer.mozilla.org/en/JavaScript/Reference)  
   * [parseFloat()](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/parseFloat)
   * [toPrecision()](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Number/toPrecision)
-
+  * [toFixed()](https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Number/toFixed)


### PR DESCRIPTION
The toFixed() method formats a number using fixed-point notation.