### PR TITLE
Updating PHP page to match PHP 8.4 news

### DIFF
--- a/content/languages/php.html
+++ b/content/languages/php.html
@@ -29,7 +29,7 @@ Rounding can be done with the `number_format()` function:
 		$number = 4.123;
 		echo number_format($number, 2); // prints 4.12
 
-If you are using either the Decimal or BcMath extensions, you can round using the `round` method:
+If you are using either the Decimal or BC Math extensions, you can round using the `round` method:
 
 		$number = new \BcMath\Number('4.123');
 		echo $number->round(2); // prints 4.12

--- a/content/languages/php.html
+++ b/content/languages/php.html
@@ -14,13 +14,13 @@ Decimal Types
 -------------
 The BC Math and Decimal extensions implement [arbitrary-precision](/formats/exact/) decimal math:
 
-		$a = '0.1';
-		$b = '0.2';
-		echo bcadd($a, $b);     // prints 0.3
+		$a = new \BcMath\Number('0.1');
+		$b = new \BcMath\Number('0.2');
+		echo $a + $b; // prints 0.3
 
-		$a = new Decimal('0.1');
-		$b = new Decimal('0.2');
-		echo $a + $b;           // prints 0.3 
+		$a = new \Decimal\Decimal('0.1');
+		$b = new \Decimal\Decimal('0.2');
+		echo $a + $b; // prints 0.3 
 
 How to Round
 ------------
@@ -29,17 +29,20 @@ Rounding can be done with the `number_format()` function:
 		$number = 4.123;
 		echo number_format($number, 2); // prints 4.12
 
-If you are using the decimal extension, you can round using the `round` method:
+If you are using either the Decimal or BcMath extensions, you can round using the `round` method:
 
-		$decimal = new Decimal("4.123");
-                echo $decimal->round(2);        // prints 4.12            
+		$number = new \BcMath\Number('4.123');
+		echo $number->round(2); // prints 4.12
+		
+		$decimal = new \Decimal\Decimal('4.123');
+		echo $decimal->round(2); // prints 4.12
 
 
 Resources 
 ---------
 * [PHP manual](http://www.php.net/manual/en/index.php)
    * [Floating point types](http://www.php.net/manual/en/language.types.float.php)
-   * [BC Math extension](http://php.net/manual/en/ref.bc.php)
-   * [Decimal extension](http://php-decimal.io)
+   * [BC Math extension](https://php.net/manual/en/book.bc.php)
+   * [Decimal extension](https://php-decimal.github.io/)
    * [number_format()](http://php.net/manual/en/function.number-format.php)
 


### PR DESCRIPTION
PHP 8.4 has news related to arbitrary precision numbers, one of them being [support object type in BCMath](https://wiki.php.net/rfc/fix_up_bcmath_number_class). 

Besides that, the link to Decimal extension was incorrect.