### PR TITLE
Update PHP Decimal extension link to GitHub Pages

### DIFF
--- a/content/languages/php.html
+++ b/content/languages/php.html
@@ -40,6 +40,6 @@ Resources
 * [PHP manual](http://www.php.net/manual/en/index.php)
    * [Floating point types](http://www.php.net/manual/en/language.types.float.php)
    * [BC Math extension](http://php.net/manual/en/ref.bc.php)
-   * [Decimal extension](http://php-decimal.io)
+   * [Decimal extension](https://php-decimal.github.io/)
    * [number_format()](http://php.net/manual/en/function.number-format.php)
 


### PR DESCRIPTION
Previous site doesn't work anymore, it has been moved to  github pages: https://php-decimal.github.io/#introduction